### PR TITLE
HvD: Hacked the libcint library into NWChem.

### DIFF
--- a/api/candoP.fh
+++ b/api/candoP.fh
@@ -24,10 +24,12 @@
 *
       logical user_cando_sp  ! did user set a value for sp 
       logical user_cando_nw  ! did user set a value for nw 
+      logical user_cando_cint! did user set a value for libcint
       logical user_cando_txs ! did user set a value for txs
       logical user_cando_hnd ! did user set a value for hnd
       logical def_cando_sp   ! default user setable value for cando_sp
       logical def_cando_nw   ! default user setable value for cando_nw
+      logical def_cando_cint ! default user setable value for cando_cint
       logical def_cando_txs  ! default user setable value for cando_txs
       logical def_cando_hnd  ! default user setable value for cando_hnd
 c
@@ -36,9 +38,10 @@ c
       logical app_stored_hnd   ! value stored in int_app_set_no_hnd
       integer rtdbIused
 c
-      common /clcando/ user_cando_sp, user_cando_nw, user_cando_txs,
-     &    user_cando_hnd,
-     &    def_cando_sp, def_cando_nw, def_cando_txs, def_cando_hnd,
+      common /clcando/ user_cando_sp, user_cando_nw, user_cando_cint, 
+     &    user_cando_txs, user_cando_hnd,
+     &    def_cando_sp, def_cando_nw, def_cando_cint, def_cando_txs,
+     &    def_cando_hnd,
      &    app_stored_txs, app_stored_spint, app_stored_hnd,
      &    rtdbIused
       

--- a/api/cando_sp.F
+++ b/api/cando_sp.F
@@ -175,6 +175,68 @@ c.... check jsh
       endif
 c
       end
+      logical function cando_cint(basisin,ish,jsh)
+      implicit none
+c 
+c:tex-For two electron cases then there are two calls to cando_cint
+c:tex-that are required with each shell pair and cooresponding 
+c:tex-basis set handle (bra or ket). 
+c
+c this routine does not check the shell and int_init
+c because it only called by routines that do this.
+c
+c
+#include "bas.fh"
+#include "errquit.fh"
+#include "nwc_const.fh"
+#include "basP.fh"
+#include "basdeclsP.fh"
+#include "geobasmapP.fh"
+#include "candoP.fh"
+#include "mafdecls.fh"
+#include "bas_ibs_dec.fh"
+c::passed
+      integer basisin !< [Input] the basis set handle for identified
+                      !< shells 
+      integer ish     !< [Input] the lexical shell index for I
+      integer jsh     !< [Input] the lexical shell index for J
+c:tex-A zero [i|j]sh means ignore this shell. this allows one function 
+c:tex-for all 2e permutations and multiple basis sets.
+c::local
+      integer basis, mytype, ucont
+c
+#include "bas_ibs_sfn.fh"
+c
+      if (user_cando_cint) then
+        cando_cint = def_cando_cint
+        return
+      endif
+c
+      cando_cint = .false.
+      return
+c
+      basis = basisin + BASIS_HANDLE_OFFSET
+c
+c check shell range
+      if (ish.lt.0 .or. ish.gt.ncont_tot_gb(basis))
+     $     call errquit('cando_cint: bad ish =', ish, UNKNOWN_ERR)
+      if (jsh.lt.0 .or. jsh.gt.ncont_tot_gb(basis))
+     $     call errquit('cando_cint: bad jsh =', jsh, UNKNOWN_ERR)
+c.... check ish
+      if (ish.gt.0) then
+        ucont  = (sf_ibs_cn2ucn(ish,basis))
+        mytype = infbs_cont(CONT_TYPE,ucont,basis)
+        cando_cint = cando_cint .and.(mytype.gt.-1) 
+      endif
+c
+c.... check jsh
+      if (jsh.gt.0) then
+        ucont  = (sf_ibs_cn2ucn(jsh,basis))
+        mytype = infbs_cont(CONT_TYPE,ucont,basis)
+        cando_cint = cando_cint .and.(mytype.gt.-1)
+      endif
+c
+      end
 ***********************************************************************
 C> \brief Checks whether the unique shell combination can be handled by
 C> the sp-rotated axis code

--- a/api/cint_wrap.F
+++ b/api/cint_wrap.F
@@ -2,9 +2,10 @@
 c store libcint environments in this module
       integer CINTnatm
       integer CINTnbas
-      integer,allocatable CINTatm(:,:)
-      integer,allocatable CINTbas(:,:)
-      double precision,allocatable CINTenv(:,:)
+      integer,allocatable :: CINTatm(:,:)
+      integer,allocatable :: CINTbas(:,:)
+c     double precision,allocatable :: CINTenv(:,:)
+      double precision,allocatable :: CINTenv(:) ! Use only as 1D array
 c initialize and delete opt by
 c call f2e_optimizer(CINTopt, CINTatm, CINTnatm, CINTbas, CINTnbas, CINTenv)
 c call CINTdel_optimizer(CINTopt)
@@ -12,24 +13,42 @@ c call CINTdel_optimizer(CINTopt)
       end module
 
 
-      subroutine init_cint_env()
+      subroutine init_cint_env(rtdb,basis)
       use cint_wrap
       implicit none
-#include "bas.fh"
+cHACK
+c     Ideally these two include files should not be here.
+c     The <name>P.fh indicates that this is a Private include file of
+c     the module indicated by <name>. Instead we should be calling
+c     the regular API functions of the BAS module. Nevertheless, let's
+c     get this stuff working first, then we can make it nice.
+#include "nwc_const.fh"
+#include "mafdecls.fh"
+#include "basdeclsP.fh"
 #include "basP.fh"
-#include "geom.fh"
 #include "bas_exndcf.fh"
-      integer offset = 0
+#include "bas_ibs_dec.fh"
+#include "geobasmapP.fh"
+#include "bas_ibs_sfn.fh"
+cHACK
+#include "errquit.fh"
+#include "bas.fh"
+#include "geom.fh"
+      integer offset
+      integer rtdb        !< [Input] The RTDB handle
       integer geom, basis       ! [input] handles
       integer natoms, nshell
       integer i, j, ptr, iat
       integer ishlo, ishhi, ish, myprim, mycont, ucont
+      logical status
       character*16 gtag         ! geometry tag 
       double precision chg
       double precision cxyz(3)
-      double precision,allocatable envbuf(:)
+      double precision,allocatable :: envbuf(:)
+      data offset/0/
 
-      status = geom_ncent(geom, natoms)
+      status = bas_geom(basis,geom)
+      status = status .and. geom_ncent(geom, natoms)
       status = status .and. bas_numcont(basis, nshell)
       if (.not. status) call errquit('cint_wrap: info failed', 0,
      &       INPUT_ERR)
@@ -78,7 +97,7 @@ c        offset = offset + 1
           CINTbas(7,ish) = offset ! pointer to contraction coefficients
           ptr = infbs_cont(CONT_ICFP,ucont,ish) - 1
           do j = 1, myprim*mycont
-            envbuf(offset+j) = sf_exndcf((ptr+j)
+            envbuf(offset+j) = sf_exndcf(ptr+j,basis)
           end do
           offset = offset + myprim*mycont
         end do
@@ -124,6 +143,6 @@ c:: local
       shls(2) = jsh - 1
       shls(3) = ksh - 1
       shls(4) = lsh - 1
-      cint2e_sph(eri, shls, CINTatm, CINTnatm, CINTbas, CINTnbas,
-     &           CINTenv, CINTopt) 
+      call cint2e_sph(eri, shls, CINTatm, CINTnatm, CINTbas, CINTnbas,
+     &                CINTenv, CINTopt) 
       end subroutine cint_2e4c

--- a/api/int_2e4c.F
+++ b/api/int_2e4c.F
@@ -93,9 +93,11 @@ c::functions
       logical cando_nw
       logical cando_sp
       logical cando_txs
+      logical cando_cint
       external cando_nw
       external cando_sp
       external cando_txs
+      external cando_cint
 #define PERF_NORMAL
 #if defined(PERF_NORMAL)
       logical int_chk_sh
@@ -130,7 +132,7 @@ c.txs
       double precision q4
       integer nint
       logical dum_log
-      logical status_sp, status_nw, status_txs, status_gen
+      logical status_sp, status_nw, status_txs, status_gen, status_cint
       integer texas_ang_limit
 c.rel-dmd
       logical status_rel, bra_rel, ket_rel
@@ -233,6 +235,9 @@ c... stat texas
       endif
 c... stat nw
       status_nw  = cando_nw(brain,ish,jsh).and.cando_nw(ketin,ksh,lsh)
+c... stat libcint
+      status_cint= cando_cint(brain,ish,jsh).and.
+     &             cando_cint(ketin,ksh,lsh)
 c... stat rel
       status_rel = dyall_mod_dir .and. .not.nesc_1e_approx
      &    .and. (brain .eq. ketin) .and. (brain .eq. ao_bsh)
@@ -272,7 +277,12 @@ c
         status_rel = status_rel .and. (bra_rel .or. ket_rel)
       end if
 c
-      if (status_sp) then
+      if (status_cint) then
+c
+        call cint_2e4c(brain,ish,jsh,ketin,ksh,lsh,
+     &                 lscr,scr,leri,eri)
+c
+      else if (status_sp) then
 c
         call genr70(
      &         brain,ish,coords(1,a_cent,ab_geom),

--- a/api/int_init.F
+++ b/api/int_init.F
@@ -179,6 +179,8 @@ C> routine reads any integral settings changed by the user from
 C> the runtime database. Only data associated with relativistic
 C> basis sets are handled in `int_init`.
 C>
+C> Variables are explained in more detail in `candoP.fh`.
+C>
       subroutine int_init_org(rtdb, nbas, bases)
 c
 c initializes integral code to data structers for a integral computation
@@ -257,10 +259,12 @@ c initialize cando information from rtdb
 c
       user_cando_sp   = .false.
       user_cando_nw   = .false.
+      user_cando_cint = .false.
       user_cando_txs  = .false.
       user_cando_hnd  = .false.
       def_cando_sp    = .false.
       def_cando_nw    = .false.
+      def_cando_cint  = .false.
       def_cando_txs   = .false.
       def_cando_hnd   = .false.
 c
@@ -280,6 +284,16 @@ c
         if (ga_nodeid().eq.0 .and. oprint) then
           write(luout,*)
      &        ' int_init: cando_nw set to always be ',def_cando_nw
+          call util_flush(luout)
+        endif
+      endif
+c
+      if (rtdb_get(rtdb,'int:cando_cint',MT_LOG,1,status)) then
+        user_cando_cint = .true.
+        def_cando_cint  = status
+        if (ga_nodeid().eq.0 .and. oprint) then
+          write(luout,*)
+     &        ' int_init: cando_cint set to always be ',def_cando_cint
           call util_flush(luout)
         endif
       endif
@@ -407,7 +421,10 @@ c
       call int_acc_std()
 * def u=f d=f -> f.and.!f -> f -> e = t
 * no txs u=t d=f -> t.and.!f -> t -> e = f
-      if (.not.(user_cando_txs.and.(.not.def_cando_txs))) then
+      if (def_cando_cint) then
+        if (nbas.ne.1) call errquit("int_init_org: nbas.ne.1",nbas,UERR)
+        call init_cint_env(rtdb,bases)
+      else if (.not.(user_cando_txs.and.(.not.def_cando_txs))) then
         call texas_init(rtdb,nbas,bases,nqmax_texas,txs_mem_min,
      *                  'scfd_int')
       else

--- a/api/int_term.F
+++ b/api/int_term.F
@@ -35,7 +35,9 @@ c
 c      
 * def u=f d=f -> f.and.!f -> f -> e = t
 * no txs u=t d=f -> t.and.!f -> t -> e = f
-      if (.not.(user_cando_txs.and.(.not.def_cando_txs))) then
+      if (def_cando_cint) then
+        call del_cint_env()
+      else if (.not.(user_cando_txs.and.(.not.def_cando_txs))) then
         call texas_terminate()
       endif
       if (.not.spcart_terminate()) then

--- a/libcint/GNUmakefile
+++ b/libcint/GNUmakefile
@@ -1,14 +1,17 @@
 # $Id: GNUmakefile 22732 2012-08-16 16:44:03Z d3y133 $
 
+OBJ = src/c2f.o src/cart2sph.o \
+      src/cint1e.o src/cint2e.o \
+      src/cint_bas.o src/fblas.o \
+      src/g1e.o src/g2e.o \
+      src/misc.o src/optimizer.o \
+      src/rys_roots.o src/autocode/auto_intor1.o \
+      src/autocode/auto_intor2.o \
+      src/autocode/auto_intor3.o \
+      src/autocode/gaunt1.o src/autocode/grad1.o \
+      src/autocode/grad2.o src/autocode/grad3.o
 
-OBJ = src/c2f.o src/cart2sph.o src/cint1e.o src/cint2e.o \
-      src/cint_bas.o src/fblas.o src/g1e.o \
-      src/g2e.o src/misc.o src/optimizer.o src/rys_roots.o \
-      src/autocode/auto_intor1.o src/autocode/auto_intor2.o \
-      src/autocode/auto_intor3.o src/autocode/gaunt1.o \
-      src/autocode/grad1.o src/autocode/grad2.o src/autocode/grad3.o
-
-HEADERS = config.h src/c2f.h src/cart2sph.h src/cint1e.h src/cint2e.h \
+HEADERS = src/c2f.h src/cart2sph.h src/cint1e.h src/cint2e.h \
           src/cint_bas.h src/cint_const.h src/fblas.h src/g1e.h src/g2e.h \
           src/misc.h src/optimizer.h src/rys_roots.h
 


### PR DESCRIPTION
I have basically added the main routines into NWChem, calling them where I
think that is sensible. In addition I have added some infrastructure that allows
one to manually enable the libcint code from the input file. A sample input
file can be found in nwchem/QA/tests/be_libcint. Currently the code still fails
as libcint detects some errors in the data structures that we initialized in
subroutine int_init_orig.
